### PR TITLE
Update the README, encourage adding scripts to README within a PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+### Description of proposed changes
+
+<!-- What is the goal of this pull request? What does this pull request change? -->
+
+### Related issue(s)
+
+<!-- Link any related issues here. -->
+
+### Checklist
+
+<!-- Make sure checks are successful at the bottom of the PR. -->
+
+- [ ] Checks pass
+- [ ] If adding a script, add an entry for it in the README.
+
+<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Potential Nextstrain CLI scripts
 
 Potential augur curate scripts
 
+- [apply-geolocation-rules](apply-geolocation-rules) - Applies user curated geolocation rules to NDJSON records
 - [merge-user-metadata](merge-user-metadata) - Merges user annotations with NDJSON records
 - [transform-authors](transform-authors) - Abbreviates full author lists to '<first author> et al.'
 - [transform-field-names](transform-field-names) - Rename fields of NDJSON records


### PR DESCRIPTION
In #4, I forgot to update the README for the addition of `apply-geolocation-rules`. Doing that in this PR. I've also added a PR template with that task in a checklist, so this is less likely to happen in the future.