### PR TITLE
trigger: Replace `repo` with `github_repo`

### DIFF
--- a/trigger
+++ b/trigger
@@ -3,7 +3,7 @@ set -euo pipefail
 
 : "${PAT_GITHUB_DISPATCH:=}"
 
-repo="${1:?A repository name is required as the first argument.}"
+github_repo="${1:?A GitHub repository with owner and repository name is required as the first argument.}"
 event_type="${2:?An event type is required as the second argument.}"
 shift 2
 
@@ -12,7 +12,7 @@ if [[ $# -eq 0 && -z $PAT_GITHUB_DISPATCH ]]; then
 You must specify options to curl for your GitHub credentials.  For example, you
 can specify your GitHub username, and will be prompted for your password:
 
-  $0 $repo $event_type --user <your-github-username>
+  $0 $github_repo $event_type --user <your-github-username>
 
 Be sure to enter a personal access token¹ as your password since GitHub has
 discontinued password authentication to the API starting on November 13, 2020².
@@ -26,7 +26,7 @@ file³:
 
 and then tell curl to use it:
 
-  $0 $repo $event_type --netrc
+  $0 $github_repo $event_type --netrc
 
 which will then not require you to type your password every time.
 
@@ -42,7 +42,7 @@ if [[ -n $PAT_GITHUB_DISPATCH ]]; then
   auth="Authorization: Bearer ${PAT_GITHUB_DISPATCH}"
 fi
 
-if curl -fsS "https://api.github.com/repos/nextstrain/${repo}/dispatches" \
+if curl -fsS "https://api.github.com/repos/${github_repo}/dispatches" \
     -H 'Accept: application/vnd.github.v3+json' \
     -H 'Content-Type: application/json' \
     -H "$auth" \

--- a/trigger-on-new-data
+++ b/trigger-on-new-data
@@ -5,7 +5,7 @@ set -euo pipefail
 
 bin="$(dirname "$0")"
 
-repo="${1:?A repository name is required as the first argument.}"
+github_repo="${1:?A GitHub repository with owner and repository name is required as the first argument.}"
 event_type="${2:?An event type is required as the second argument.}"
 metadata="${3:?A metadata upload output file is required as the third argument.}"
 sequences="${4:?An sequence FASTA upload output file is required as the fourth argument.}"
@@ -19,7 +19,7 @@ slack_message=""
 # grep exit status 0 for found match, 1 for no match, 2 if an error occurred
 if [[ $new_metadata -eq 1 || $new_sequences -eq 1 ]]; then
     slack_message="Triggering new builds due to updated metadata and/or sequences"
-    "$bin"/trigger "$repo" "$event_type"
+    "$bin"/trigger "$github_repo" "$event_type"
 elif [[ $new_metadata -eq 0 && $new_sequences -eq 0 ]]; then
     slack_message="Skipping trigger of rebuild: Both metadata TSV and sequences FASTA are identical to S3 files."
 else


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

As previously done¹ for the notify scripts, use GitHub repos by org/name pair to make scripts more generalizable. This will also work really well with the `GITHUB_REPOSITORY` variable available for GitHub Action workflows.

¹ b2a0de70342cef1b2b27f3f139af262910466b24

### Related issue(s)

<!-- Link any related issues here. -->

Prompted by https://github.com/nextstrain/monkeypox/pull/167#discussion_r1287790924

### Checklist

<!-- Make sure checks are successful at the bottom of the PR. -->

- [x] Checks pass
- [x] ~If adding a script, add an entry for it in the README.~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
