### PR TITLE
Add fetch-from-ncbi-entrez

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Scripts for supporting ingest workflow automation that don’t really belong in 
 - [trigger-on-new-data](trigger-on-new-data) - Triggers downstream GitHub Actions if the provided `upload-to-s3` outputs do not contain the `identical_file_message`
   A hacky way to ensure that we only trigger downstream phylogenetic builds if the S3 objects have been updated.
 
+NCBI interaction scripts that are useful for fetching public metadata and sequences.
+
+- [fetch-from-ncbi-entrez](fetch-from-ncbi-entrez) - Fetch metadata and nucleotide sequences from [NCBI Entrez](https://www.ncbi.nlm.nih.gov/books/NBK25501/) and output to a GenBank file.
+  Useful for pathogens with metadata and annotations in custom fields that are not part of the standard [NCBI Virus](https://www.ncbi.nlm.nih.gov/labs/virus/vssi/) or [NCBI Datasets](https://www.ncbi.nlm.nih.gov/datasets/) outputs.
+
 Potential Nextstrain CLI scripts
 
 - [sha256sum](sha256sum) - Used to check if files are identical in upload-to-s3 and download-from-s3 scripts.

--- a/fetch-from-ncbi-entrez
+++ b/fetch-from-ncbi-entrez
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-
+"""
+Fetch metadata and nucleotide sequences from NCBI Entrez and output to a GenBank file.
+"""
 import json
 import argparse
 from Bio import SeqIO, Entrez
@@ -14,8 +16,9 @@ MAX_IDS = 100_100
 Entrez.email = "hello@nextstrain.org"
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='Annotate sequences using a genbank reference')
-    parser.add_argument('--term', help='Genbank search term. Replace spaces with "+"', default='Hepatitis+B+virus[All+Fields]complete+genome[All+Fields]')
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--term', required=True, type=str,
+        help='Genbank search term. Replace spaces with "+", e.g. "Hepatitis+B+virus[All+Fields]complete+genome[All+Fields]"')
     parser.add_argument('--output', required=True, type=str, help='Output file (Genbank)')
     return parser.parse_args()
 
@@ -35,7 +38,7 @@ def fetch(id_list):
 
 if __name__=="__main__":
     args = parse_args()
-    
+
     genomes = []
     for id_list in get_sequence_ids(args.term):
         genomes.extend(fetch(id_list))

--- a/fetch-from-ncbi-entrez
+++ b/fetch-from-ncbi-entrez
@@ -65,8 +65,6 @@ def fetch_from_esearch_history(count, query_key, web_env):
 if __name__=="__main__":
     args = parse_args()
 
-    genomes = []
-    for batch_results in fetch_from_esearch_history(**get_esearch_history(args.term)):
-        genomes.extend(batch_results)
-
-    SeqIO.write(genomes, args.output, "genbank")
+    with open(args.output, "w") as output_handle:
+        for batch_results in fetch_from_esearch_history(**get_esearch_history(args.term)):
+            SeqIO.write(batch_results, output_handle, "genbank")

--- a/fetch-from-ncbi-entrez
+++ b/fetch-from-ncbi-entrez
@@ -6,12 +6,11 @@ import json
 import argparse
 from Bio import SeqIO, Entrez
 
-# to use the efetch API, the docs indicate only around 200 IDs should be provided per request
+# To use the efetch API, the docs indicate only around 10,000 records should be fetched per request
 # https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.EFetch
-BATCH_SIZE = 200
-
-# As of mid 2023 there are ~11k records for HBV
-MAX_IDS = 100_100
+# However, in my testing with HepB, the max records returned was 9,999
+#   - Jover, 16 August 2023
+BATCH_SIZE = 9999
 
 Entrez.email = "hello@nextstrain.org"
 
@@ -22,25 +21,52 @@ def parse_args():
     parser.add_argument('--output', required=True, type=str, help='Output file (Genbank)')
     return parser.parse_args()
 
-def get_sequence_ids(term):
-    handle = Entrez.esearch(db="nucleotide", term=term, retmode="json", retmax=MAX_IDS)
-    data = json.loads(handle.read())
-    ids = data['esearchresult']['idlist']
-    print(f"Search term '{term}' returned {len(ids)} IDs. Processing in batches of n={BATCH_SIZE}.")
-    idx = 0
-    while idx < len(ids):
-        yield ids[idx:idx+BATCH_SIZE]
-        idx+=BATCH_SIZE
 
-def fetch(id_list):
-    handle = Entrez.efetch(db="nucleotide", id=','.join(id_list), rettype="gb", retmode="text")
-    return SeqIO.parse(handle, "genbank")
+def get_esearch_history(term):
+    """
+    Search for the provided *term* via ESearch and store the results using the
+    Entrez history server.¹
+
+    Returns the total count of returned records, query key, and web env needed
+    to access the records from the server.
+
+    ¹ https://www.ncbi.nlm.nih.gov/books/NBK25497/#chapter2.Using_the_Entrez_History_Server
+    """
+    handle = Entrez.esearch(db="nucleotide", term=term, retmode="json", usehistory="y", retmax=0)
+    esearch_result = json.loads(handle.read())['esearchresult']
+    print(f"Search term {term!r} returned {esearch_result['count']} IDs.")
+    return {
+        "count": int(esearch_result["count"]),
+        "query_key": esearch_result["querykey"],
+        "web_env": esearch_result["webenv"]
+    }
+
+
+def fetch_from_esearch_history(count, query_key, web_env):
+    """
+    Fetch records in batches from Entrez history server using the provided
+    *query_key* and *web_env* and yields them as a BioPython SeqRecord iterator.
+    """
+    print(f"Fetching GenBank records in batches of n={BATCH_SIZE}")
+
+    for start in range(0, count, BATCH_SIZE):
+        handle = Entrez.efetch(
+            db="nucleotide",
+            query_key=query_key,
+            webenv=web_env,
+            retstart=start,
+            retmax=BATCH_SIZE,
+            rettype="gb",
+            retmode="text")
+
+        yield SeqIO.parse(handle, "genbank")
+
 
 if __name__=="__main__":
     args = parse_args()
 
     genomes = []
-    for id_list in get_sequence_ids(args.term):
-        genomes.extend(fetch(id_list))
+    for batch_results in fetch_from_esearch_history(**get_esearch_history(args.term)):
+        genomes.extend(batch_results)
 
     SeqIO.write(genomes, args.output, "genbank")

--- a/fetch-from-ncbi-entrez
+++ b/fetch-from-ncbi-entrez
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import json
+import argparse
+from Bio import SeqIO, Entrez
+
+# to use the efetch API, the docs indicate only around 200 IDs should be provided per request
+# https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.EFetch
+BATCH_SIZE = 200
+
+# As of mid 2023 there are ~11k records for HBV
+MAX_IDS = 100_100
+
+Entrez.email = "hello@nextstrain.org"
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Annotate sequences using a genbank reference')
+    parser.add_argument('--term', help='Genbank search term. Replace spaces with "+"', default='Hepatitis+B+virus[All+Fields]complete+genome[All+Fields]')
+    parser.add_argument('--output', required=True, type=str, help='Output file (Genbank)')
+    return parser.parse_args()
+
+def get_sequence_ids(term):
+    handle = Entrez.esearch(db="nucleotide", term=term, retmode="json", retmax=MAX_IDS)
+    data = json.loads(handle.read())
+    ids = data['esearchresult']['idlist']
+    print(f"Search term '{term}' returned {len(ids)} IDs. Processing in batches of n={BATCH_SIZE}.")
+    idx = 0
+    while idx < len(ids):
+        yield ids[idx:idx+BATCH_SIZE]
+        idx+=BATCH_SIZE
+
+def fetch(id_list):
+    handle = Entrez.efetch(db="nucleotide", id=','.join(id_list), rettype="gb", retmode="text")
+    return SeqIO.parse(handle, "genbank")
+
+if __name__=="__main__":
+    args = parse_args()
+    
+    genomes = []
+    for id_list in get_sequence_ids(args.term):
+        genomes.extend(fetch(id_list))
+
+    SeqIO.write(genomes, args.output, "genbank")


### PR DESCRIPTION
### Description of proposed changes

Copies the fetch-genbank script from hepatitisB with the thought that future pathogens may also need to parse GenBank fields that are not immediately available through NCBI Virus or NCBI Datasets.

I made some modifications to the Entrez interactions within the script, but the interface remains the same and I verified that the output for the HepB search term is identical before and after updates. 

### Related issue(s)

Subset of scripts listed in #1 

### Checklist

<!-- Make sure checks are successful at the bottom of the PR. -->

- [x] Checks pass
- [x] If adding a script, add an entry for it in the README.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
