### PR TITLE
README: Add warning about rebasing + git subrepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ Any future updates of ingest scripts can be pulled in with:
 git subrepo pull ingest/vendored
 ```
 
+> **Warning**
+> Beware of rebasing/dropping the parent commit of a `git subrepo` update
+
+`git subrepo` relies on metadata in the `ingest/vendored/.gitrepo` file,
+which includes the hash for the parent commit in the pathogen repos.
+If this hash no longer exists in the commit history, there will be errors when
+running future `git subrepo pull` commands.
+
+If you run into an error similar to the following:
+```
+$ git subrepo pull ingest/vendored
+git-subrepo: Command failed: 'git branch subrepo/ingest/vendored '.
+fatal: not a valid object name: ''
+```
+Check the parent commit hash in the `ingest/vendored/.gitrepo` file and make
+sure the commit exists in the commit history. Update to the appropriate parent
+commit hash if needed.
+
 ## History
 
 Much of this tooling originated in


### PR DESCRIPTION
### Description of proposed changes

Add a warning about rebasing + git subrepo in the README so that it's visible in every pathogen repo that vendors the ingest scripts. 

### Related issue(s)

Resolves #21 

### Checklist

<!-- Make sure checks are successful at the bottom of the PR. -->

- [x] Checks pass
- [ ] If adding a script, add an entry for it in the README.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
