### PR TITLE
README: Update `git subrepo pull` with `--force` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ Any future updates of ingest scripts can be pulled in with:
 git subrepo pull ingest/vendored
 ```
 
+If you run into merge conflicts and would like to pull in a fresh copy of the
+latest ingest scripts, pull with the `--force` flag:
+
+```
+git subrepo pull ingest/vendored --force
+```
+
 > **Warning**
 > Beware of rebasing/dropping the parent commit of a `git subrepo` update
 


### PR DESCRIPTION
In walking through `git subrepo pull` with @j23414 for monkeypox, we ran into unexpected merge conflicts.¹

Reading through the git subrepo docs,² I found that we can just make a clean "reclone" of the subrepo with the `--force` flag. Instead of working through the conflict resolution, the forced reclone made sense for just getting the latest version of the ingest repo.

If we are operating on a "pull-only" model for vendoring the ingest repo, using the `--force` flag seems like a reasonable default.

¹ https://gist.github.com/joverlee521/b00739c3dcbff66ca99828d43cb80a42 
² https://github.com/ingydotnet/git-subrepo#commands


### Checklist

<!-- Make sure checks are successful at the bottom of the PR. -->

- [ ] Checks pass
- [ ] If adding a script, add an entry for it in the README.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
