### PR TITLE
`transform-field-names`: Skip field if `old_field_name` == `new_field_name`

### DIFF
--- a/tests/transform-field-names/transform-field-names.t
+++ b/tests/transform-field-names/transform-field-names.t
@@ -1,0 +1,27 @@
+Verify behavior of `transform-field-names`
+
+If the `--field-map` includes a old field name that is the same as the new field
+name, this prints a loud warning.
+
+  $ echo '{"strain": "A"}' \
+  >  | $TESTDIR/../../transform-field-names \
+  >      --field-map "strain=strain"
+  WARNING: skipping rename of strain because record already has a field named strain.
+  {"strain":"A"}
+
+If the `--field-map` overwrites an existing field, then skip renaming and
+print a loud warning.
+
+  $ echo '{"strain": "A", "isolate": "B"}' \
+  >  | $TESTDIR/../../transform-field-names \
+  >      --field-map "isolate=strain"
+  WARNING: skipping rename of isolate because record already has a field named strain.
+  {"strain":"A","isolate":"B"}
+
+The `--field-map` may overwrite an existing field if using `--force` flag.
+
+  $ echo '{"strain": "A", "isolate": "B"}' \
+  >  | $TESTDIR/../../transform-field-names \
+  >      --field-map "isolate=strain" \
+  >      --force
+  {"strain":"B"}

--- a/tests/transform-field-names/transform-field-names.t
+++ b/tests/transform-field-names/transform-field-names.t
@@ -1,12 +1,11 @@
 Verify behavior of `transform-field-names`
 
 If the `--field-map` includes a old field name that is the same as the new field
-name, this prints a loud warning.
+name, this should be no-op.
 
   $ echo '{"strain": "A"}' \
   >  | $TESTDIR/../../transform-field-names \
   >      --field-map "strain=strain"
-  WARNING: skipping rename of strain because record already has a field named strain.
   {"strain":"A"}
 
 If the `--field-map` overwrites an existing field, then skip renaming and

--- a/transform-field-names
+++ b/transform-field-names
@@ -16,8 +16,9 @@ if __name__ == '__main__':
     parser.add_argument("--field-map", nargs="+",
         help="Fields names in the NDJSON record mapped to new field names, " +
              "formatted as '{old_field_name}={new_field_name}'. " +
-             "If the old field does not exist in record, the new field will be added with an empty string value." +
-             "If the new field already exists in record, then the renaming of the old field will be skipped.")
+             "If the old field does not exist in record, the new field will be added with an empty string value. " +
+             "If the new field already exists in record, then the renaming of the old field will be skipped. " +
+             "Skips the field if the old field name is the same as the new field name (case-sensitive).")
     parser.add_argument("--force", action="store_true",
         help="Force renaming of old field even if the new field already exists. " +
              "Please keep in mind this will overwrite the value of the new field.")
@@ -27,6 +28,10 @@ if __name__ == '__main__':
     field_map = {}
     for field in args.field_map:
         old_name, new_name = field.split('=')
+
+        if old_name == new_name:
+            continue
+
         field_map[old_name] = new_name
 
     for record in stdin:


### PR DESCRIPTION
### Description of proposed changes

If the old field name is the same as the new field name (case sensitive), then skip renaming. 

Resolves #37 

### Checklist

<!-- Make sure checks are successful at the bottom of the PR. -->

- [x] Checks pass
- [ ] ~If adding a script, add an entry for it in the README.~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
