### PR TITLE
notify-slack: Migrate to new upload APIs

### DIFF
--- a/notify-slack
+++ b/notify-slack
@@ -40,14 +40,14 @@ if [[ "$upload" == 1 ]]; then
 
     upload_info=$(curl https://slack.com/api/files.getUploadURLExternal \
         --header "Authorization: Bearer $SLACK_TOKEN" \
-        --form filename="$text" \
-        --form length="$length" \
+        --form-string filename="$text" \
+        --form-string length="$length" \
         --fail --silent --show-error \
         --http1.1 )
 
     upload_url="$(jq -r .upload_url <<< "$upload_info")"
     curl "$upload_url" \
-        --form filename="$text" \
+        --form-string filename="$text" \
         --form file="@$upload_file" \
         --fail --silent --show-error \
         --http1.1 > /dev/null

--- a/notify-slack
+++ b/notify-slack
@@ -31,17 +31,37 @@ text="${1:?Some message text is required.}"
 
 if [[ "$upload" == 1 ]]; then
     echo "Uploading data to Slack with the message: $text"
-    curl https://slack.com/api/files.upload \
+
+    upload_file="$(mktemp -t upload-file-XXXXXX)"
+    trap "rm -f '$upload_file'" EXIT
+
+    cat /dev/stdin > "$upload_file"
+    length=$(printf '%d' "$(<"$upload_file" wc -c)")
+
+    upload_info=$(curl https://slack.com/api/files.getUploadURLExternal \
         --header "Authorization: Bearer $SLACK_TOKEN" \
-        --form-string channels="$SLACK_CHANNELS" \
-        --form-string title="$text" \
-        --form-string filename="$text" \
+        --form filename="$text" \
+        --form length="$length" \
+        --fail --silent --show-error \
+        --http1.1 )
+
+    upload_url="$(jq -r .upload_url <<< "$upload_info")"
+    curl "$upload_url" \
+        --form filename="$text" \
+        --form file="@$upload_file" \
+        --fail --silent --show-error \
+        --http1.1 > /dev/null
+
+    files_uploaded="$(jq -r "[{id: .file_id}]" <<< "$upload_info")"
+    curl -X POST https://slack.com/api/files.completeUploadExternal \
+        --header "Authorization: Bearer $SLACK_TOKEN" \
+        --form-string channel_id="$SLACK_CHANNELS" \
         --form-string thread_ts="$thread_ts" \
-        --form file=@/dev/stdin \
-        --form filetype=text \
+        --form-string files="$files_uploaded" \
         --fail --silent --show-error \
         --http1.1 \
         --output "$output"
+
 else
     echo "Posting Slack message: $text"
     curl https://slack.com/api/chat.postMessage \


### PR DESCRIPTION


### Description of proposed changes

The `files.upload` API will be sunset on March 11, 2025.¹ This commit follows Slack's "Uploading files" docs² to migrate to the new upload APIs, `files.getUploadURLExternal` and `files.completeUploadExternal`.

The usage of the script does not change. However, the new API requires the channels to be provided as their channel IDs instead of channel names, so we will have to update the `SLACK_CHANNELS` envvar for various pathogen workflows. Channel ids are more stable anyways since channels can be renamed.

¹ <https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay> 
² <https://api.slack.com/messaging/files#uploading_files>

### Related issue(s)

Resolves https://github.com/nextstrain/ingest/issues/46

### Checklist

<!-- Make sure checks are successful at the bottom of the PR. -->

- [x] Checks pass
- [x] If adding a script, add an entry for it in the README.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
