### PR TITLE
Swap `ubuntu-24.04` for `ubuntu-latest` in GH Actions [.github#113]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   shellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: nextstrain/.github/actions/shellcheck@master

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3
 repos:
   - repo: https://github.com/pre-commit/sync-pre-commit-deps
-    rev: v0.0.1
+    rev: v0.0.3
     hooks:
       - id: sync-pre-commit-deps
   - repo: https://github.com/shellcheck-py/shellcheck-py
@@ -10,12 +10,12 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.6.27
+    rev: v1.7.7
     hooks:
       - id: actionlint
         entry: env SHELLCHECK_OPTS='--exclude=SC2027' actionlint
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: check-ast
@@ -34,7 +34,7 @@ repos:
       - id: fix-byte-order-marker
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.6
+    rev: v0.9.10
     hooks:
       # Run the linter.
       - id: ruff


### PR DESCRIPTION
### Description of proposed changes

Swaps over to explict `ubuntu-24.04` runner

### Related issue(s)

nextstrain/.github#113

### Checklist

<!-- Make sure checks are successful at the bottom of the PR. -->

- [ ] Checks pass
- [ ] If adding a script, add an entry for it in the README.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
